### PR TITLE
Add message helper functions and tests

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -344,6 +344,53 @@ def delete_contact(contact_id):
         return False
 
 # =============================================================================
+# FUNCIONES PARA MANEJO DE MENSAJES
+# =============================================================================
+def add_message(texto):
+    """Agrega un nuevo mensaje y retorna su id."""
+    try:
+        with get_connection() as con:
+            cur = con.cursor()
+            cur.execute(
+                "INSERT INTO mensajes (descripcion) VALUES (?)",
+                (texto.strip(),),
+            )
+            con.commit()
+            return cur.lastrowid
+    except Exception as e:
+        st.error(f"Error al agregar mensaje: {e}")
+        return None
+
+
+def update_message(msg_id, nuevo_texto):
+    """Actualiza el texto de un mensaje."""
+    try:
+        with get_connection() as con:
+            cur = con.cursor()
+            cur.execute(
+                "UPDATE mensajes SET descripcion = ? WHERE id = ?",
+                (nuevo_texto.strip(), msg_id),
+            )
+            con.commit()
+            return cur.rowcount > 0
+    except Exception as e:
+        st.error(f"Error al actualizar el mensaje: {e}")
+        return False
+
+
+def delete_message(msg_id):
+    """Elimina un mensaje por id."""
+    try:
+        with get_connection() as con:
+            cur = con.cursor()
+            cur.execute("DELETE FROM mensajes WHERE id = ?", (msg_id,))
+            con.commit()
+            return cur.rowcount > 0
+    except Exception as e:
+        st.error(f"Error al eliminar el mensaje: {e}")
+        return False
+
+# =============================================================================
 # FUNCION: GENERAR ARCHIVO HTML
 # =============================================================================
 def apply_template(template, contacto):

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,0 +1,73 @@
+import sys
+import os
+from unittest.mock import MagicMock, patch
+import sqlite3
+import importlib
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def import_app():
+    with patch.dict(
+        sys.modules,
+        {
+            "streamlit": MagicMock(),
+            "pandas": MagicMock(),
+            "requests": MagicMock(),
+            "bs4": MagicMock(),
+        },
+    ):
+        sys.path.insert(0, ROOT)
+        import src.app
+
+        importlib.reload(src.app)
+        sys.path.remove(ROOT)
+        return src.app
+
+
+def make_memory_db():
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE mensajes (id INTEGER PRIMARY KEY AUTOINCREMENT, descripcion TEXT NOT NULL)"
+    )
+    return conn
+
+
+def test_add_message():
+    conn = make_memory_db()
+    app = import_app()
+    with patch.object(app, "get_connection", return_value=conn):
+        msg_id = app.add_message("Hola")
+    cur = conn.cursor()
+    cur.execute("SELECT descripcion FROM mensajes WHERE id=?", (msg_id,))
+    row = cur.fetchone()
+    assert row[0] == "Hola"
+
+
+def test_update_message():
+    conn = make_memory_db()
+    cur = conn.cursor()
+    cur.execute("INSERT INTO mensajes (descripcion) VALUES ('Old')")
+    msg_id = cur.lastrowid
+    conn.commit()
+    app = import_app()
+    with patch.object(app, "get_connection", return_value=conn):
+        result = app.update_message(msg_id, "New")
+    assert result is True
+    cur.execute("SELECT descripcion FROM mensajes WHERE id=?", (msg_id,))
+    assert cur.fetchone()[0] == "New"
+
+
+def test_delete_message():
+    conn = make_memory_db()
+    cur = conn.cursor()
+    cur.execute("INSERT INTO mensajes (descripcion) VALUES ('Temp')")
+    msg_id = cur.lastrowid
+    conn.commit()
+    app = import_app()
+    with patch.object(app, "get_connection", return_value=conn):
+        result = app.delete_message(msg_id)
+    assert result is True
+    cur.execute("SELECT COUNT(*) FROM mensajes WHERE id=?", (msg_id,))
+    assert cur.fetchone()[0] == 0
+


### PR DESCRIPTION
## Summary
- implement `add_message`, `update_message` and `delete_message` helpers
- add unit tests for message helper functions using an in-memory database

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854cae50dd8832ba64f07590124e5e0