### PR TITLE
Add optional HTML image via file type

### DIFF
--- a/tests/test_generate_html.py
+++ b/tests/test_generate_html.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import importlib
+from unittest.mock import MagicMock, patch
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def import_app():
+    with patch.dict(
+        sys.modules,
+        {
+            "streamlit": MagicMock(),
+            "pandas": MagicMock(),
+            "requests": MagicMock(),
+            "bs4": MagicMock(),
+        },
+    ):
+        sys.path.insert(0, ROOT)
+        import src.app
+        importlib.reload(src.app)
+        sys.path.remove(ROOT)
+        return src.app
+
+
+def test_generate_html_includes_image():
+    app = import_app()
+    df = MagicMock()
+    class Row(dict):
+        def to_dict(self):
+            return dict(self)
+
+    df.iterrows.return_value = iter([(0, Row({"telefono": "912345678", "auto": "A", "nombre": "X"}))])
+    content, name = app.generate_html(df, "Hola", image_bytes=b"abc", image_type="image/png")
+    html = content.decode("utf-8")
+    assert "data:image" in html
+    assert "CONTACTO 1" in html


### PR DESCRIPTION
## Summary
- avoid `imghdr` deprecation by using the uploaded file's MIME type
- pass image type when generating HTML
- adjust unit test for new parameter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685609e86424832b8a3af35bb8103c10