### PR TITLE
Add basic user authentication

### DIFF
--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -28,7 +28,7 @@ def import_app():
 def make_memory_db():
     conn = sqlite3.connect(":memory:")
     conn.execute(
-        "CREATE TABLE mensajes (id INTEGER PRIMARY KEY AUTOINCREMENT, descripcion TEXT NOT NULL)"
+        "CREATE TABLE mensajes (id INTEGER PRIMARY KEY AUTOINCREMENT, descripcion TEXT NOT NULL, user_id INTEGER)"
     )
     return conn
 


### PR DESCRIPTION
## Summary
- create users table and migration helpers
- implement auth helpers and login/logout flow in the Streamlit app
- restrict queries by user_id and add admin user page
- update message functions to store user_id
- adapt tests for new mensaje schema

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859f65361a4832ba21953c1ed24ad5b