### PR TITLE
Add rotating messages to HTML export

### DIFF
--- a/tests/test_generate_html.py
+++ b/tests/test_generate_html.py
@@ -2,6 +2,7 @@ import os
 import sys
 import importlib
 from unittest.mock import MagicMock, patch
+import urllib.parse
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
@@ -38,3 +39,29 @@ def test_generate_html_creates_links():
     html = content.decode("utf-8")
     assert "CONTACTO 1" in html
     assert "data:image" not in html
+
+
+def test_generate_html_rotates_messages():
+    app = import_app()
+    df = MagicMock()
+
+    class Row(dict):
+        def to_dict(self):
+            return dict(self)
+
+    rows = [
+        Row({"telefono": "911111111", "auto": "A", "nombre": "Uno"}),
+        Row({"telefono": "922222222", "auto": "B", "nombre": "Dos"}),
+    ]
+    df.iterrows.return_value = iter(enumerate(rows))
+    msgs = ["Hola {nombre}", "Adios {auto}"]
+    content, _ = app.generate_html(df, msgs)
+    html = content.decode("utf-8")
+    links = [
+        urllib.parse.unquote(part.split("=")[1])
+        for part in [link.split("?")[1] for link in [
+            l.split('"')[1] for l in html.splitlines() if "href=" in l
+        ]]
+    ]
+    assert "Hola Uno" in links[0]
+    assert "Adios B" in links[1]


### PR DESCRIPTION
## Summary
- allow multiple WhatsApp message templates when generating HTML
- update export page to select several templates and cycle them per contact
- record the message ID used for each contact in export logs
- expand unit tests for HTML generation to cover rotating messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c21a3bf9c832ba4045dde4f1f7ce1