### PR TITLE
feat: add WhatsApp chat window

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ python run.py
 Para instrucciones detalladas, consulta
 [docs/README.md](docs/README.md).
 
+## CWS Chat WhatsApp
+
+La ventana **CWS Chat WhatsApp** permite seleccionar un *Link Contactos* y
+varias plantillas de mensaje para cada contacto. La tabla resultante muestra
+auto, precio, teléfono y un enlace al anuncio. Cada fila incluye un botón
+**Enviar_WS** que abre una conversación en WhatsApp con un mensaje
+personalizado y copia el texto en un cuadro HTML que dispone de un botón
+**Copiar**.
+
 ## Pruebas
 
 ```bash

--- a/tests/test_cws_links.py
+++ b/tests/test_cws_links.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import importlib
+import urllib.parse
+from unittest.mock import MagicMock, patch
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def import_app():
+    with patch.dict(
+        sys.modules,
+        {
+            "streamlit": MagicMock(),
+            "streamlit.components": MagicMock(),
+            "streamlit.components.v1": MagicMock(),
+            "pandas": MagicMock(),
+            "requests": MagicMock(),
+            "bs4": MagicMock(),
+        },
+    ):
+        sys.path.insert(0, ROOT)
+        import src.app
+        importlib.reload(src.app)
+        sys.path.remove(ROOT)
+        return src.app
+
+
+def test_build_whatsapp_link_rotates_templates():
+    app = import_app()
+    contacto = {"telefono": "911111111", "nombre": "Ana", "auto": "Sedan"}
+    plantillas = ["Hola {nombre}", "Adios {auto}"]
+    with patch.object(app.random, "choice", side_effect=plantillas):
+        url1, msg1 = app.build_whatsapp_link(plantillas, contacto)
+        url2, msg2 = app.build_whatsapp_link(plantillas, contacto)
+    assert msg1 == "Hola Ana"
+    assert msg2 == "Adios Sedan"
+    assert url1.startswith("https://wa.me/56")
+    assert urllib.parse.unquote(url1.split("?text=")[1]) == msg1
+    assert urllib.parse.unquote(url2.split("?text=")[1]) == msg2

--- a/tests/test_generate_html.py
+++ b/tests/test_generate_html.py
@@ -12,6 +12,8 @@ def import_app():
         sys.modules,
         {
             "streamlit": MagicMock(),
+            "streamlit.components": MagicMock(),
+            "streamlit.components.v1": MagicMock(),
             "pandas": MagicMock(),
             "requests": MagicMock(),
             "bs4": MagicMock(),

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -12,6 +12,8 @@ def import_app():
         sys.modules,
         {
             "streamlit": MagicMock(),
+            "streamlit.components": MagicMock(),
+            "streamlit.components.v1": MagicMock(),
             "pandas": MagicMock(),
             "requests": MagicMock(),
             "bs4": MagicMock(),

--- a/tests/test_sanitize_links.py
+++ b/tests/test_sanitize_links.py
@@ -12,6 +12,8 @@ def import_app():
         sys.modules,
         {
             "streamlit": MagicMock(),
+            "streamlit.components": MagicMock(),
+            "streamlit.components.v1": MagicMock(),
             "requests": MagicMock(),
             "bs4": MagicMock(),
             "pandas": MagicMock(),

--- a/tests/test_search_contacts.py
+++ b/tests/test_search_contacts.py
@@ -45,6 +45,8 @@ def import_app():
         sys.modules,
         {
             "streamlit": MagicMock(),
+            "streamlit.components": MagicMock(),
+            "streamlit.components.v1": MagicMock(),
             "requests": MagicMock(),
             "bs4": MagicMock(),
             "pandas": fake_pd,

--- a/tests/test_update_contact.py
+++ b/tests/test_update_contact.py
@@ -12,6 +12,8 @@ def import_app():
         sys.modules,
         {
             "streamlit": MagicMock(),
+            "streamlit.components": MagicMock(),
+            "streamlit.components.v1": MagicMock(),
             "pandas": MagicMock(),
             "requests": MagicMock(),
             "bs4": MagicMock(),


### PR DESCRIPTION
## Summary
- add CWS Chat WhatsApp page with random-template message links
- show message box with copy button for quick reuse
- test WhatsApp link builder for template rotation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4b8df759c832ba1e8e69199cc5daa