### PR TITLE
Fix CWS WhatsApp send button using markdown

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -12,7 +12,7 @@ import sys
 import hashlib
 import random
 import json
-import streamlit.components.v1 as components
+from html import escape
 
 
 def resource_path(relative_path):
@@ -1120,25 +1120,22 @@ elif page == "CWS Chat WhatsApp":
                             plantillas, row.to_dict()
                         )
                         msg_js = json.dumps(msg)
+                        js_code = (
+                            f"const msg = {msg_js}; "
+                            "document.getElementById('cws-msg').value = msg; "
+                            f"window.open('{link}', '_blank');"
+                        )
+                        button_html = f'<button onclick="{escape(js_code, quote=True)}">Enviar_WS</button>'
                         with cols[4]:
-                            components.html(
-                                f"""
-<button onclick="
-    const msg = {msg_js};
-    document.getElementById('cws-msg').value = msg;
-    window.open('{link}', '_blank');
-">Enviar_WS</button>
-""",
-                                height=40,
-                            )
-                    components.html(
+                            st.markdown(button_html, unsafe_allow_html=True)
+                    st.markdown(
                         """
 <div>
   <textarea id='cws-msg' style='width:100%;height:100px;'></textarea>
   <button onclick="navigator.clipboard.writeText(document.getElementById('cws-msg').value)">Copiar</button>
 </div>
 """,
-                        height=150,
+                        unsafe_allow_html=True,
                     )
             else:
                 st.info("Seleccione al menos una plantilla.")


### PR DESCRIPTION
## Summary
- Escape WhatsApp button script to avoid Markdown code blocks and render a clickable button

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4c2f534f8832b8ddcf6564e37f8ed