### PR TITLE
Fix HTML quoting for WhatsApp button

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1119,14 +1119,11 @@ elif page == "CWS Chat WhatsApp":
                             plantillas, row.to_dict()
                         )
                         msg_js = json.dumps(msg)
+                        link_js = json.dumps(link)
                         with cols[4]:
                             st.markdown(
                                 f"""
-<button onclick="
-    const msg = {msg_js};
-    document.getElementById('cws-msg').value = msg;
-    window.open('{link}', '_blank');
-">Enviar_WS</button>
+<button onclick='const msg = {msg_js}; document.getElementById("cws-msg").value = msg; window.open({link_js}, "_blank");'>Enviar_WS</button>
 """,
                                 unsafe_allow_html=True,
                             )


### PR DESCRIPTION
## Summary
- fix WhatsApp message button by using proper HTML quoting
- ensure generated link and message are safely serialized with `json.dumps`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4c60cd4a0832b9b3662125021ea53